### PR TITLE
add fix for environments without DOM access (webworkers, node)

### DIFF
--- a/sobel.js
+++ b/sobel.js
@@ -83,16 +83,29 @@
       }
     }
 
-    var clampedArray = new Uint8ClampedArray(sobelData);
+    var clampedArray = sobelData;
+
+    if (typeof Uint8ClampedArray !== 'undefined') {
+      clampedArray = new Uint8ClampedArray(sobelData);
+    }
+
     clampedArray.toImageData = function() {
-      try {
-        return new ImageData(clampedArray, w, h);
-      } catch(error) {
-        var canvas = document.createElement('canvas');
-        var context =  canvas.getContext('2d');
-        var imageData = context.createImageData(w, h);
-        imageData.data.set(clampedArray);
-        return imageData;
+      if (typeof window === 'undefined') {
+        return {
+          width: w,
+          height: h,
+          data: clampedArray
+        };
+      } else {
+        if (typeof ImageData === 'undefined') {
+          return new ImageData(clampedArray, w, h);
+        } else {
+          var canvas = document.createElement('canvas');
+          var context =  canvas.getContext('2d');
+          var imageData = context.createImageData(w, h)
+          imageData.data.set(clampedArray);
+          return imageData;
+        }
       }
     };
 

--- a/sobel.js
+++ b/sobel.js
@@ -98,13 +98,13 @@
         };
       } else {
         if (typeof ImageData === 'undefined') {
-          return new ImageData(clampedArray, w, h);
-        } else {
           var canvas = document.createElement('canvas');
           var context =  canvas.getContext('2d');
           var imageData = context.createImageData(w, h)
           imageData.data.set(clampedArray);
           return imageData;
+        } else {
+          return new ImageData(clampedArray, w, h);
         }
       }
     };


### PR DESCRIPTION
Hey @miguelmota,

thank you for creating this library. It is super useful, and I use it in one of my projects. 

I noticed a small issue when trying to use it in environments without DOM access, like inside a webworker or in node. In these environments `document.createElement('canvas')` is not available, so I added a workaround for that.

In addition to that, I also noticed, that in some browsers `Uint8ClampedArray` is not available. in this case I made it return the original sobelData instead of a copy.

Please have a look at the changes I made and let me know what you think. Thank you.

Have a great day!
